### PR TITLE
Extend `token` description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a fork of [SwiftDocOrg/github-wiki-publish-action](https://githu
 | ---------------- | -------- | ----------------------------------------------------- | -------------------------------------------------------------------------- |
 | `source`         | yes      | -                                                     | Source directory/location of file sync (ex: `docs`).                       |
 | `destination`    | yes      | -                                                     | Destination directory/location for file sync (ex: `wiki`).                 |
-| `token`          | yes      | -                                                     | Github personal access token with at least 'repo' authorization.           |
+| `token`          | yes      | -                                                     | Github personal access token with at least 'Repository permissions'->'Contents' authorization. More info [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)                                              |
 | `gitAuthorName`  | no       | `github.actor`                                        | Author name to use for committing to repository.                           |
 | `gitAuthorEmail` | no       | `github.actor@users.noreply.github.com`               | Author name to use for committing to repository.                           |
 | `branch`         | no       | `master`                                              | Default branch to commit to. Only needed when syncing wiki to a directory. |


### PR DESCRIPTION
I spent too much time trying to figure out how to connect the right token, I hope this will help others :)
![image](https://github.com/user-attachments/assets/11ebd71a-470e-4f06-8849-f1cb59014fa0)

Just in case, I'm not the only one who has encountered this problem. #3 